### PR TITLE
Simplify the Load Image Batch node

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,6 @@
     - Restart ComfyUI
     - WAS Suite should uninstall legacy nodes automatically for you.
     - Tools will be located in the WAS Suite menu.
+    - (For the Load Image Batch node) you need the extension from [Incremental Wiget](https://github.com/Slarper/incremental-widget)
 
 *This version renames some nodes, as well as introduces new fields. Unfortunately ComfyUI doesn't handle these changes well, so you'll have to replace the dreaded "red nodes" manually.*


### PR DESCRIPTION
This PR is like:

PROS:
Largely simplified the Load Image Batch node.


_Before:_
![Screenshot 2023-03-26 154712](https://user-images.githubusercontent.com/98243861/227763049-ed7f3b12-6d26-43f8-8670-e79da77522f9.png)

 
_After:_ 

![Screenshot 2023-03-26 152557](https://user-images.githubusercontent.com/98243861/227763043-33531fa0-eeda-473b-9ae9-c2c691f85192.png)

Main changes:
The old version used a counter file to store the current image index temporarily, it's an overhead.
Through a custom widget, the new version use an input `index` to store the current image index. So now the current image index is a parameter of our workflow.
Besides, the old version used a `mode` to switch between 'single' and 'incremental' mode. In the new version, we use a toggle under the `index` to do it, the `increment after every gen`. how it works is similar to the `seed` widget in KSampler node.

The `image_id` is redundant now, so i deleted it.

The ONLY cons:
it'll make the Load Image Batch node depend on the extension: [Incremental Widget](https://github.com/Slarper/incremental-widget)

Hope to be merged.☺️