### PR TITLE
Add support for Segment Anything (SAM)

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -4592,9 +4592,6 @@ class WAS_SAM_Image_Mask:
         points = sam_parameters["points"]
         labels = sam_parameters["labels"]
         
-        print(points)
-        print(labels)
-        
         from segment_anything import SamPredictor
         
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')


### PR DESCRIPTION
This implements part of #32, namely support for loading SAM and generating masks using it. It's a bit rough around the edges though, so I'll keep working on it:
- Not really sure whether most users will have enough VRAM to run the model(s) on their GPU if SD is loaded. Maybe add a cpu/gpu flag in either the model loader or image mask node?
- I noticed the BLIP download URL can be configured, should do the same for SAM.
- SAM also supports being passed a bounding box to further refine what you're trying to get it to mask, but I haven't implemented that yet.
- Would also like to add cropping and blend nodes that can use these masks along with a padding amount to enable crop-upscale-diffuse-downscale-blend workflows.

Here's what the two nodes in a workflow look like- you give SAM an arbitrary list of points, and whether the point should be "in" the mask or "outside" of it- and it does the rest:
![sam-test](https://user-images.githubusercontent.com/3847023/230482130-ed8c54d6-6525-4124-bf47-ba873ce0b9a5.png)

Let me know if you have any feedback, and I'll continue working on it.