### PR TITLE
Adjust load_images Method to Ensure Correct File Paths

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -4885,8 +4885,8 @@ class WAS_Load_Image_Batch:
         def load_images(self, directory_path, pattern):
             for file_name in glob.glob(os.path.join(directory_path, pattern), recursive=True):
                 if file_name.lower().endswith(ALLOWED_EXT):
-                    image_path = os.path.join(directory_path, file_name)
-                    self.image_paths.append(image_path)
+                    abs_file_path = os.path.abspath(file_name)
+                    self.image_paths.append(abs_file_path)
 
         def get_image_by_id(self, image_id):
             if image_id < 0 or image_id >= len(self.image_paths):


### PR DESCRIPTION
This pull request addresses an issue found in the `load_images` method of the `BatchImageLoader` class, where the method could potentially generate incorrect and duplicated file paths.

The `load_images` function used the `glob.glob` function to get the filenames from a specific directory, and then it appended the directory path to the filenames. However, since `glob.glob` already returns the full path (including the directory path), appending the directory path again resulted in duplicated paths.

To fix this issue, the code was refactored to add the result from `glob.glob` directly to `self.image_paths`, as `glob.glob` already provides a complete path. Furthermore, to handle all potential edge cases, the absolute path of each file is ensured using `os.path.abspath`. 

The revised `load_images` method is as follows:

```python
def load_images(self, directory_path, pattern):
    for file_name in glob.glob(os.path.join(directory_path, pattern), recursive=True):
        if file_name.lower().endswith(ALLOWED_EXT):
            # Ensure the file path is absolute
            abs_file_path = os.path.abspath(file_name)
            self.image_paths.append(abs_file_path)
```

With this change, we can now ensure that the load_images method always generates correct file paths, regardless of whether glob.glob returns relative or absolute paths.

Please let me know if you have any questions or concerns about this change.