### PR TITLE
Fix output path handling on WAS_Create_Video_From_Path

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12092,12 +12092,16 @@ class WAS_Create_Video_From_Path:
             fps = 60
             
         tokens = TextTokens()
-        output_path = os.path.abspath(os.path.join(*tokens.parseTokens(output_path).split('/')))
+
+        # Check if output_path is an absolute path
+        if not os.path.isabs(output_path):
+            output_path = os.path.abspath(os.path.join(*tokens.parseTokens(output_path).split('/')))
+
         output_file = os.path.join(output_path, tokens.parseTokens(filename))
-        
+
         if not os.path.exists(output_path):
             os.makedirs(output_path, exist_ok=True)
-        
+
         WTools = WAS_Tools_Class()
         MP4Writer = WTools.VideoWriter(int(transition_frames), int(fps), int(image_delay_sec), max_size, codec)
         path = MP4Writer.create_video(input_path, output_file)


### PR DESCRIPTION
Had issues when using absolute paths in the video output, would still try to append to ComfyUI directory + output path.

System I am using is Ubuntu 22.04.