### PR TITLE
Allow minimum setting to 1 so that no file padding is done

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -6540,7 +6540,7 @@ class WAS_Image_Save:
                 "output_path": ("STRING", {"default": '[time(%Y-%m-%d)]', "multiline": False}),
                 "filename_prefix": ("STRING", {"default": "ComfyUI"}),
                 "filename_delimiter": ("STRING", {"default":"_"}),
-                "filename_number_padding": ("INT", {"default":4, "min":2, "max":9, "step":1}),
+                "filename_number_padding": ("INT", {"default":4, "min":1, "max":9, "step":1}),
                 "extension": (['png', 'jpeg', 'gif', 'tiff', 'webp'], ),
                 "quality": ("INT", {"default": 100, "min": 1, "max": 100, "step": 1}),
                 "lossless_webp": (["false", "true"],),


### PR DESCRIPTION
In a case where no file padding is wanted we can set this to 1. Setting to 1 looks like this output:
1.png
2.png
3.png
...
9.png
10.png
11.png