### PR TITLE
Was int counter

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12354,6 +12354,28 @@ class WAS_Samples_Passthrough_Stat_System:
 
         return [ram_stats, vram_stats, hard_drive_stats]
 
+# Class to count the number of places on an integer
+
+class WAS_Integer_Place_Counter:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "int_input": ("INT", {"default": 0, "min": 0, "max": 10000000, "step": 1}),
+            }
+        }
+    RETURN_TYPES = ("INT",)
+    RETURN_NAMES = ("INT_PLACES",)
+    FUNCTION = "count_places"
+
+    CATEGORY = "WAS Suite/Integer"
+
+    def count_places(self, int_input):
+        output = len(str(int_input))
+        cstr("\nInteger Places Count: "+str(output)).msg.print()
+        return (output,)
+
+
 # NODE MAPPING
 NODE_CLASS_MAPPINGS = {
     "BLIP Model Loader": WAS_BLIP_Model_Loader,
@@ -12445,6 +12467,7 @@ NODE_CLASS_MAPPINGS = {
     "Image to Latent Mask": WAS_Image_To_Mask,
     "Image to Noise": WAS_Image_To_Noise,
     "Image to Seed": WAS_Image_To_Seed,
+    "Integer place counter": WAS_Integer_Place_Counter,
     "Image Voronoi Noise Filter": WAS_Image_Voronoi_Noise_Filter,
     "KSampler (WAS)": WAS_KSampler,
     "KSampler Cycle": WAS_KSampler_Cycle,

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -6540,7 +6540,7 @@ class WAS_Image_Save:
                 "output_path": ("STRING", {"default": '[time(%Y-%m-%d)]', "multiline": False}),
                 "filename_prefix": ("STRING", {"default": "ComfyUI"}),
                 "filename_delimiter": ("STRING", {"default":"_"}),
-                "filename_number_padding": ("INT", {"default":4, "min":2, "max":9, "step":1}),
+                "filename_number_padding": ("INT", {"default":4, "min":1, "max":9, "step":1}),
                 "extension": (['png', 'jpeg', 'gif', 'tiff', 'webp'], ),
                 "quality": ("INT", {"default": 100, "min": 1, "max": 100, "step": 1}),
                 "lossless_webp": (["false", "true"],),


### PR DESCRIPTION
I added a node to count the places of an int. 

This combined with WAS Image Save can allow for a workflow that loads an image (ex: 9.png), img2img the loaded image, then save a 10.png (with WAS Image Save). The key feature of this is it allows for no padding of the input number (see a previous PR from me) when connected to the filename_number_padding input on WAS Image Save and the source int connected to a load file. Think of crude animation framing.

I can provide a more detailed use case for this if necessary, I'm sure others will be able to use it for something.

TLDR: It allows it to count past 9 without manually changing the filename_number_padding value manually.