### PR TITLE
add WAS_Mask_Batch (pack multiple individual masks to batch)

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -4367,7 +4367,7 @@ class WAS_Image_Displacement_Warp:
 
         return image
         
-# IMAGE TO NOISE
+# IMAGE TO BATCH
 
 class WAS_Image_Batch:
     def __init__(self):
@@ -4410,6 +4410,50 @@ class WAS_Image_Batch:
         batched_tensors = torch.cat(batched_tensors, dim=0)
         return (batched_tensors,)
         
+
+# MASK TO BATCH
+
+class WAS_Mask_Batch:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "optional": {
+                "masks_a": ("MASK",),
+                "masks_b": ("MASK",),
+                "masks_c": ("MASK",),
+                "masks_d": ("MASK",),
+                # "masks_e": ("MASK",),
+                # "masks_f": ("MASK",),
+                # Theoretically, an infinite number of mask input parameters can be added.
+            },
+        }
+
+    RETURN_TYPES = ("MASK",)
+    RETURN_NAMES = ("masks",)
+    FUNCTION = "mask_batch"
+    CATEGORY = "WAS Suite/Mask"
+
+    def _check_mask_dimensions(self, tensors, names):
+        dimensions = [tensor.shape[1:] for tensor in tensors]  # Exclude the batch dimension (if present)
+        if len(set(dimensions)) > 1:
+            mismatched_indices = [i for i, dim in enumerate(dimensions) if dim != dimensions[0]]
+            mismatched_masks = [names[i] for i in mismatched_indices]
+            raise ValueError(f"WAS Mask Batch Warning: Input mask dimensions do not match for masks: {mismatched_masks}")
+
+    def mask_batch(self, **kwargs):
+        batched_tensors = [kwargs[key] for key in kwargs if kwargs[key] is not None]
+        mask_names = [key for key in kwargs if kwargs[key] is not None]
+
+        if not batched_tensors:
+            raise ValueError("At least one input mask must be provided.")
+
+        self._check_mask_dimensions(batched_tensors, mask_names)
+        batched_tensors = torch.stack(batched_tensors, dim=0)
+        batched_tensors = batched_tensors.unsqueeze(1)  # Add a channel dimension
+        return (batched_tensors,)
 
 # IMAGE GENERATE COLOR PALETTE
 
@@ -12489,6 +12533,7 @@ NODE_CLASS_MAPPINGS = {
     "Masks Subtract": WAS_Mask_Subtract,
     "Mask Arbitrary Region": WAS_Mask_Arbitrary_Region,
     "Mask Batch to Mask": WAS_Mask_Batch_to_Single_Mask,
+    "Mask Batch": WAS_Mask_Batch,
     "Mask Ceiling Region": WAS_Mask_Ceiling_Region,
     "Mask Crop Dominant Region": WAS_Mask_Crop_Dominant_Region,
     "Mask Crop Minority Region": WAS_Mask_Crop_Minority_Region,


### PR DESCRIPTION
Hi there,

Similar to the WAS_Image_Batch class, the purpose of WAS_Mask_Batch is to pack multiple individual masks with consistent tensor shapes into a batch. It can be understood as the reverse process of WAS_Mask_Batch_to_Single_Mask and is very useful in specific scenarios. 

<img width="1473" alt="image" src="https://github.com/WASasquatch/was-node-suite-comfyui/assets/33664979/6955c8b8-c3ee-4d55-bd26-e21cd5a5ab66">

You need to review the function names and node names, and you can redefine them according to the project's conventions.

Thanks!