### PR TITLE
Allow inline bools

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -11735,7 +11735,7 @@ class WAS_Image_Input_Switch:
             "required": {
                 "image_a": ("IMAGE",),
                 "image_b": ("IMAGE",),
-                "boolean_number": ("NUMBER",),
+                "boolean_number": ("INT", {"default":1, "min":0, "max":1, "step":1}),
             }
         }
 


### PR DESCRIPTION
Right now, if you want to pass a 0 or 1 to most nodes, you need a logic bool node running to it. 

It'd be nicer if you had the option to use an input widget in cases where you want to just set the value directly. I've only done image input because that's the one I use the most but should be pretty easy to implement this across all the logic nodes.