### PR TITLE
Enable comparison of empty strings

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -9350,7 +9350,10 @@ class WAS_Text_Compare:
                                 similar_words.add(word1)
                             if word2 not in similar_words:
                                 similar_words.add(word2)
-            similarity_score = 1 - (dp[m][n]/max(m,n))
+            if(max(m,n) == 0):
+                similarity_score = 1
+            else:
+                similarity_score = 1 - (dp[m][n]/max(m,n))
             return (similarity_score, list(similar_words))
 
 


### PR DESCRIPTION
When trying to compare two empty strings this node errors out because "can't devide by 0". My workaround enables comparison of empty strings, so I can automate using one prompt if another is empty, or the other, if it's not empty.