### PR TITLE
Updated WAS_Bounded_Image_Blend, WAS_Bounded_Image_Blend_With_Mask, and WAS_Image_Batch

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -4561,9 +4561,10 @@ class WAS_Image_Batch:
     def _check_image_dimensions(self, tensors, names):
         dimensions = [tensor.shape for tensor in tensors]
         if len(set(dimensions)) > 1:
-            mismatched_indices = [i for i, dim in enumerate(dimensions) if dim != dimensions[0]]
+            mismatched_indices = [i for i, dim in enumerate(dimensions) if dim[1:] != dimensions[0][1:]]
             mismatched_images = [names[i] for i in mismatched_indices]
-            raise ValueError(f"WAS Image Batch Warning: Input image dimensions do not match for images: {mismatched_images}")
+            if mismatched_images:
+                raise ValueError(f"WAS Image Batch Warning: Input image dimensions do not match for images: {mismatched_images}")
 
     def image_batch(self, **kwargs):
         batched_tensors = [kwargs[key] for key in kwargs if kwargs[key] is not None]

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -11067,7 +11067,7 @@ class WAS_Bounded_Image_Blend:
         # Convert PyTorch tensors to PIL images
         target_pil = Image.fromarray((target.squeeze(0).cpu().numpy() * 255).clip(0, 255).astype(np.uint8))
         source_pils = []
-        if source.ndim > 3:
+        if source.shape[0] > 1:
             for source_img in source:
                 source_pils.append(Image.fromarray((source_img.squeeze(0).cpu().numpy() * 255).astype(np.uint8)))
         else:


### PR DESCRIPTION
Updated WAS_Bounded_Image_Blend and WAS_Bounded_Image_Blend_With_Mask to support multiple `source` inputs (still only supports a single `target` input).

Tested with both single and multiple `source` inputs, and the original functionality using a single `source` input is unchanged.