### PR TITLE
Add LORA input switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
      - `    "wildcards_path": "E:\\python\\automatic\\webui3\\stable-diffusion-webui\\extensions\\sd-dynamic-prompts\\wildcards"`
      - If no path is set the wildcards dir is located at the root of WAS Node Suite as `/wildcards`
  - CLIP Input Switch: Switch between two CLIP inputs based on a boolean switch.
- - CLIP Vision Input Switch: Switch between two CLIP Vision inputs based on a boolean swith.
+ - CLIP Vision Input Switch: Switch between two CLIP Vision inputs based on a boolean switch.
  - Conditioning Input Switch: Switch between two conditioning inputs.
  - Constant Number
  - Control Net Model Input Switch: Switch between two Control Net Model inputs based on a boolean switch.
@@ -95,7 +95,7 @@
  - Image Generate Gradient: Generate a gradient map with desired stops and colors
  - Image High Pass Filter: Apply a high frequency pass to the image returning the details
  - Image History Loader: Load images from history based on the Load Image Batch node. Can define max history in config file. *(requires restart to show last sessions files at this time)*
- - Image Input Switch: Switch between two image inputs
+ - Image Input Switch: Switch between two image inputs based on a boolean switch
  - Image Levels Adjustment: Adjust the levels of a image
  - Image Load: Load a *image* from any path on the system, or a url starting with `http`
  - Image Median Filter: Apply a median filter to a image, such as to smooth out details in surfaces
@@ -184,15 +184,16 @@
  - Latent Noise Injection: Inject latent noise into a latent image
  - Latent Size to Number: Latent sizes in tensor width/height
  - Latent Upscale by Factor: Upscale a latent image by a factor
- - Latent Input Switch: Switch between two latent inputs 
+ - Latent Input Switch: Switch between two latent inputs based on a boolean switch
  - Logic Boolean: A simple `1` or `0` output to use with logic
+ - Lora Input Switch: Switch between two LORAs based on a boolean switch
  - MiDaS Model Loader: Load a MiDaS model as an optional input for MiDaS Depth Approximation
  - MiDaS Depth Approximation: Produce a depth approximation of a single image input
  - MiDaS Mask Image: Mask a input image using MiDaS with a desired color
  - Number Operation
  - Number to Seed
  - Number to Float
- - Number Input Switch: Switch between two number inputs
+ - Number Input Switch: Switch between two number inputs based on a boolean switch
  - Number Input Condition: Compare between two inputs or against the A input
  - Number to Int
  - Number to String

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12692,6 +12692,34 @@ class WAS_unCLIP_Checkpoint_Loader:
         out = comfy.sd.load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, output_clipvision=True, embedding_directory=comfy_paths.get_folder_paths("embeddings"))
         return (out[0], out[1], out[2], out[3], os.path.splitext(os.path.basename(ckpt_name))[0])
 
+
+class WAS_Lora_Input_Switch:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_a": ("MODEL",),
+                "clip_a": ("CLIP",),
+                "model_b": ("MODEL",),
+                "clip_b": ("CLIP",),
+                "boolean_number": ("NUMBER",),
+            }
+        }
+    RETURN_TYPES = ("MODEL", "CLIP")
+    FUNCTION = "lora_input_switch"
+
+    CATEGORY = "WAS Suite/Logic"
+
+    def lora_input_switch(self, model_a, clip_a, model_b, clip_b, boolean_number=1):
+        if int(round(boolean_number)) == 1:
+            return (model_a, clip_a)
+        else:
+            return (model_b, clip_b)
+
+
 class WAS_Lora_Loader:
     def __init__(self):
         self.loaded_lora = None;
@@ -13284,6 +13312,7 @@ NODE_CLASS_MAPPINGS = {
     "Load Image Batch": WAS_Load_Image_Batch,
     "Load Text File": WAS_Text_Load_From_File,
     "Load Lora": WAS_Lora_Loader,
+    "Lora Input Switch": WAS_Lora_Input_Switch,
     "Masks Add": WAS_Mask_Add,
     "Masks Subtract": WAS_Mask_Subtract,
     "Mask Arbitrary Region": WAS_Mask_Arbitrary_Region,


### PR DESCRIPTION
I used this to generate a large set random images for review and refinement later. Rather than have multiple LORAs present and all fighting with each other, this new node allows us to load just 1 LORA at a time.  The choice of LORA can be made random with the "random number" node.