### PR TITLE
Load Images node should support path with special character. 

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -5116,7 +5116,7 @@ class WAS_Load_Image_Batch:
             self.label = label
 
         def load_images(self, directory_path, pattern):
-            for file_name in glob.glob(os.path.join(directory_path, pattern), recursive=True):
+            for file_name in glob.glob(os.path.join(glob.escape(directory_path), pattern), recursive=True):
                 if file_name.lower().endswith(ALLOWED_EXT):
                     abs_file_path = os.path.abspath(file_name)
                     self.image_paths.append(abs_file_path)


### PR DESCRIPTION
Some of the images I have is a directory with path containing `[` or `]` character. This is interpret by the `glob.glob()` function as a pattern rather than parts of the path.  This results in image list being empty and cause `index out of bound` error.

This patch escape the path so it's not considered as a pattern.

Without this patch, the user has to enter the escaped path instead which can be tricky. 