### PR TITLE
Fix for TypeError: get_torch_device_name() missing 1 required positio…

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -828,11 +828,13 @@ class TextTokens:
             self.WDB.insertCat('custom_tokens')
         self.custom_tokens = self.WDB.getDict('custom_tokens')
         
+        device = comfy.model_management.get_torch_device()
+
         self.tokens = {
             '[time]': str(time.time()).replace('.','_'),
             '[hostname]': socket.gethostname(),
-            '[cuda_device]': comfy.model_management.get_torch_device(),
-            '[cuda_name]': comfy.model_management.get_torch_device_name(),
+            '[cuda_device]': str(device),
+            '[cuda_name]': str(comfy.model_management.get_torch_device_name(device)),
         }
 
         if '.' in self.tokens['[time]']:


### PR DESCRIPTION
Fix for TypeError when getting torch device name due to missing torch.device object parameter

Also convert 'torch.device' object to string to prevent error when decoding to str