### PR TITLE
Optimization of Config File Path Handling with Environment Variable S…

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -145,10 +145,12 @@ MIDAS_INSTALLED = False
 CUSTOM_NODES_DIR = comfy_paths.folder_names_and_paths["custom_nodes"][0][0]
 MODELS_DIR =  comfy_paths.models_dir
 WAS_SUITE_ROOT = os.path.dirname(NODE_FILE)
-WAS_DATABASE = os.path.join(WAS_SUITE_ROOT, 'was_suite_settings.json')
-WAS_HISTORY_DATABASE = os.path.join(WAS_SUITE_ROOT, 'was_history.json')
-WAS_CONFIG_FILE = os.path.join(WAS_SUITE_ROOT, 'was_suite_config.json')
-STYLES_PATH = os.path.join(WAS_SUITE_ROOT, 'styles.json')
+WAS_CONFIGS_DIR = os.environ.get('WAS_CONFIGS_DIR', WAS_SUITE_ROOT)
+WAS_DATABASE = os.path.join(WAS_CONFIGS_DIR, 'was_suite_settings.json')
+WAS_HISTORY_DATABASE = os.path.join(WAS_CONFIGS_DIR, 'was_history.json')
+WAS_CONFIG_FILE = os.path.join(WAS_CONFIGS_DIR, 'was_suite_config.json')
+STYLES_PATH = os.path.join(WAS_CONFIGS_DIR, 'styles.json')
+DEFAULT_NSP_PANTRY_PATH = os.path.join(WAS_CONFIGS_DIR, 'nsp_pantry.json')
 ALLOWED_EXT = ('.jpeg', '.jpg', '.png',
                         '.tiff', '.gif', '.bmp', '.webp')
                         
@@ -470,7 +472,7 @@ def nsp_parse(text, seed=0, noodle_key='__', nspterminology=None, pantry_path=No
     if nspterminology is None:
         # Fetch the NSP Pantry
         if pantry_path is None:
-            pantry_path = os.path.join(WAS_SUITE_ROOT, 'nsp_pantry.json')
+            pantry_path = DEFAULT_NSP_PANTRY_PATH
         if not os.path.exists(pantry_path):
             response = urlopen('https://raw.githubusercontent.com/WASasquatch/noodle-soup-prompts/main/nsp_pantry.json')
             tmp_pantry = json.loads(response.read())


### PR DESCRIPTION
Hello! I've noticed that the current project has some limitations in managing the paths of configuration files, especially across different environments. To enhance the flexibility and maintainability of the project, I propose a small but significant improvement as follows:

I've introduced a new WAS_CONFIGS_DIR parameter, designated for storing various .json configuration files.
WAS_CONFIGS_DIR first attempts to retrieve its value from the system environment variable WAS_CONFIGS_DIR. If the environment variable is not set, it defaults to using WAS_SUITE_ROOT as the directory for configuration files.
The advantage of this change is that it offers users greater flexibility to define the location of their configuration files as per their requirements. Moreover, this modification is backward compatible—if users have not set any environment variable, the project will continue to use WAS_SUITE_ROOT as the storage path for configuration files as before. This means that this change will not affect the normal usage of existing users.

I kindly ask you to consider accepting this modification. I believe that it will make the project more flexible and powerful in its future development. Should there be any questions or further discussions needed, please feel free to contact me.

Thank you once again for your hard work and dedication to this project!