### PR TITLE
fix Image_Bounds_to_Console label handling

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -11650,8 +11650,8 @@ class WAS_Image_Bounds_to_Console:
 
     def debug_to_console(self, image_bounds, label):
         label_out = 'Debug to Console'
-        if label.strip() == '':
-            lable_out = label
+        if label.strip() != '':
+            label_out = label
 
         bounds_out = 'Empty'
         if len(bounds_out) > 0:


### PR DESCRIPTION
The logic is backwards, which is a good thing because the variable name is wrong too.