### PR TITLE
feat: option to disable whitespace cleanup in "Text Concatenate"

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -9883,6 +9883,7 @@ class WAS_Text_Concatenate:
         return {
             "required": {
                 "delimiter": ("STRING", {"default": ", "}),
+                "clean_whitespace": (["true", "false"],),
             },
             "optional": {
                 "text_a": (TEXT_TYPE, {"forceInput": (True if TEXT_TYPE == 'STRING' else False)}),
@@ -9897,7 +9898,7 @@ class WAS_Text_Concatenate:
 
     CATEGORY = "WAS Suite/Text"
 
-    def text_concatenate(self, delimiter, **kwargs):
+    def text_concatenate(self, delimiter, clean_whitespace, **kwargs):
         text_inputs: list[str] = []
 
         # Handle special case where delimiter is "\n" (literal newline).
@@ -9910,10 +9911,14 @@ class WAS_Text_Concatenate:
 
             # Only process string input ports.
             if isinstance(v, str):
-                # Remove all leading and trailing whitespace.
-                v = v.strip()
+                if clean_whitespace == "true":
+                    # Remove leading and trailing whitespace around this input.
+                    v = v.strip()
 
-                # Only use this input if it's a non-empty string.
+                # Only use this input if it's a non-empty string, since it
+                # never makes sense to concatenate totally empty inputs.
+                # NOTE: If whitespace cleanup is disabled, inputs containing
+                # 100% whitespace will be treated as if it's a non-empty input.
                 if v != "":
                     text_inputs.append(v)
 


### PR DESCRIPTION
Closes #310 

This new feature makes it possible to keep all messy whitespace that comes into the text concatenation node. Most people won't want this, so it's off by default.

It also makes the node's UI a bit more cluttered with 1 extra option, which isn't even useful at all for Stable Diffusion (since SD doesn't care at all about whitespace).

But there's one usage for it: [Manually creating "pretty formatted" text strings for debug printing to the console](https://github.com/WASasquatch/was-node-suite-comfyui/issues/310#issuecomment-1870380079). Is it worth adding a whole option to the node and making the UI "bigger" just for that? I don't really think so, but it's not my call to make, and it was requested by at least 1 person who has a usage case for it! :)

Edit: See next message for a screenshot of the new mode.