### PR TITLE
add kwargs argument as a workaround to ignore boolean_number arguments

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12961,7 +12961,7 @@ class WAS_VAE_Input_Switch:
 
     CATEGORY = "WAS Suite/Logic"
 
-    def vae_switch(self, vae_a, vae_b, boolean=True):
+    def vae_switch(self, vae_a, vae_b, boolean=True, **kwargs):
 
         if boolean:
             return (vae_a, )


### PR DESCRIPTION
add kwargs argument as a workaround to ignore boolean_number arguments passed to the function

I encountered and reported #issue 364. This change seems to avoid this error on my local.

I know that this is BAD CODE! I'm a .NET developer by trade, but I could navigate python enough to identify this workaround, but I also know enough to assume it's VERY BAD and DOES NOT ACTUALLY SOLVE THE PROBLEM. However, this does avoid the error on my local, so far as I can tell, and I'm hoping maybe a PR might prompt somebody to make a proper fix?

Honestly, this is my first time making a PR to a public repo, so please be nice?