### PR TITLE
Add step to constant number and fix typo

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -12025,7 +12025,7 @@ class WAS_Constant_Number:
         return {
             "required": {
                 "number_type": (["integer", "float", "bool"],),
-                "number": ("FLOAT", {"default": 0, "min": -18446744073709551615, "max": 18446744073709551615}),
+                "number": ("FLOAT", {"default": 0, "min": -18446744073709551615, "max": 18446744073709551615, "step": 0.01}),
             },
             "optional": {
                 "number_as_text": (TEXT_TYPE, {"forceInput": (True if TEXT_TYPE == 'STRING' else False)}),
@@ -12051,7 +12051,7 @@ class WAS_Constant_Number:
         if number_type:
             if number_type == 'integer':
                 return (int(number), float(number), int(number) )
-            elif number_type == 'integer':
+            elif number_type == 'float':
                 return (float(number), float(number), int(number) )
             elif number_type == 'bool':
                 boolean = (1 if float(number) > 0.5 else 0)


### PR DESCRIPTION
Other nodes have a step of 0.01 so I also added it to the constant number, unless there was a reason it wasn't there.
I also noticed an unreachable elif in the same node so I'm assuming that was a typo.