### PR TITLE
WAS_Image_Save Images output

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7165,7 +7165,9 @@ class WAS_Image_Save:
             },
         }
 
-    RETURN_TYPES = ()
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("images",)
+    
     FUNCTION = "was_save_images"
 
     OUTPUT_NODE = True
@@ -7360,9 +7362,9 @@ class WAS_Image_Save:
                 results.append(image_data)
 
         if show_previews == 'true':
-            return {"ui": {"images": results}}
+            return {"ui": {"images": results}, "result": (images,)}
         else:
-            return {"ui": {"images": []}}
+            return {"ui": {"images": []}, "result": (images,)}
 
     def get_subfolder_path(self, image_path, output_path):
         output_parts = output_path.strip(os.sep).split(os.sep)


### PR DESCRIPTION
WAS_Image_Save
an images output was added to firstly force saving before the images are sent to the next group/node and secondly to have the possibility to bypass the node. so that saving can be switched on/off if necessary and the images can still be forwarded through the node to the next node in line.