### PR TITLE
Fix to "Text Parse A1111 Embeddings"

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -9819,7 +9819,7 @@ class WAS_Text_Parse_Embeddings_By_Name:
         for embeddings_path in comfy_paths.folder_names_and_paths["embeddings"][0]:
             for filename in os.listdir(embeddings_path):
                 basename, ext = os.path.splitext(filename)
-                pattern = re.compile(r'\b{}\b'.format(re.escape(basename)))
+                pattern = re.compile(r'\b(?<!embedding:){}\b'.format(re.escape(basename)))
                 replacement = 'embedding:{}'.format(basename)
                 text = re.sub(pattern, replacement, text)
 


### PR DESCRIPTION
It sometimes adds "embedding:" multiple times to the same embedding. This change prevents that.
#249 is the issue, however the change cjps-br posted didn't work for my circumstance.