### PR TITLE
Fix type check & clean redundant code

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -11169,7 +11169,7 @@ class WAS_Text_To_Number:
     CATEGORY = "WAS Suite/Text/Operations"
 
     def text_to_number(self, text):
-        if text.replace(".", "").isnumeric():
+        if "." in text:
             number = float(text)
         else:
             number = int(text)

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -9703,9 +9703,7 @@ class WAS_Text_Multiline:
         new_text = []
         for line in io.StringIO(text):
             if not line.strip().startswith('#'):
-                if not line.strip().startswith("\n"):
-                    line = line.replace("\n", '')
-                new_text.append(line)
+                new_text.append(line.replace("\n", ''))
         new_text = "\n".join(new_text)
 
         tokens = TextTokens()
@@ -10737,8 +10735,6 @@ class WAS_Text_File_History:
         lines = []
         for line in io.StringIO(text):
             if not line.strip().startswith('#'):
-                if not line.strip().startswith("\n"):
-                    line = line.replace("\n", '')
                 lines.append(line.replace("\n",''))
         dictionary = {filename: lines}
 
@@ -10998,11 +10994,7 @@ class WAS_Text_Load_From_File:
         lines = []
         for line in io.StringIO(text):
             if not line.strip().startswith('#'):
-                if ( not line.strip().startswith("\n")
-                    or not line.strip().startswith("\r")
-                    or not line.strip().startswith("\r\n") ):
-                    line = line.replace("\n", '').replace("\r",'').replace("\r\n",'')
-                lines.append(line.replace("\n",'').replace("\r",'').replace("\r\n",''))
+                lines.append(line.replace("\n",'').replace("\r",''))
         dictionary = {filename: lines}
 
         return ("\n".join(lines), dictionary)


### PR DESCRIPTION
Removes a few redundant code paths.

Second commit fixes an issue instead of just removing the redundant code path.  The backing type of returned number _can_ now be int.  Would probably be better in a `try / except`, but I tried to keep to the original intent.