### PR TITLE
Fix return types of WAS_Find

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10368,8 +10368,8 @@ class WAS_Find:
             }
         }
 
-    RETURN_TYPES = ("BOOLEAN")
-    RETURN_NAMES = ("found")
+    RETURN_TYPES = ("BOOLEAN",)
+    RETURN_NAMES = ("found",)
     FUNCTION = "execute"
 
     CATEGORY = "WAS Suite/Text/Search"


### PR DESCRIPTION
The `RETURN_TYPES` and `RETURN_NAMES` need to be tuple of single item.