### PR TITLE
Fixing broken node WAS_Find ("Text Find")

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10370,8 +10370,8 @@ class WAS_Find:
             }
         }
 
-    RETURN_TYPES = ("BOOLEAN")
-    RETURN_NAMES = ("found")
+    RETURN_TYPES = ("BOOLEAN",)
+    RETURN_NAMES = ("found",)
     FUNCTION = "execute"
 
     CATEGORY = "WAS Suite/Text/Search"
@@ -10380,7 +10380,7 @@ class WAS_Find:
         if substring:
             return substring in text
 
-        return bool(re.search(pattern, text))
+        return (bool(re.search(pattern, text)),)
 
 
 


### PR DESCRIPTION
This node was broken : in the GUI there were 7 individual outputs named "f", "o", "u", "n", "d", "A", "N" instead of one named "found" of type boolean.

GUI before fix:

![before](https://github.com/user-attachments/assets/fe36f9a1-be6f-4ee8-8431-a2587fadcaf8)

GUI after fix:

![after](https://github.com/user-attachments/assets/de0e1e1f-a580-4710-a1c0-821628aa57fd)

JSON node definition from /object_info endpoint before fix:

```json
{
  "input": {
    "required": {
      "text": [
        "STRING",
        {
          "forceInput": true
        }
      ],
      "substring": [
        "STRING",
        {
          "default": "",
          "multiline": false
        }
      ],
      "pattern": [
        "STRING",
        {
          "default": "",
          "multiline": false
        }
      ]
    }
  },
  "output": "BOOLEAN",
  "output_is_list": [
    false,
    false,
    false,
    false,
    false,
    false,
    false
  ],
  "output_name": "found",
  "name": "Text Find",
  "display_name": "Text Find",
  "description": "",
  "python_module": "custom_nodes.was-node-suite-comfyui",
  "category": "WAS Suite/Text/Search",
  "output_node": false
}
```

JSON node definition from /object_info endpoint after fix:

```json
{
  "input": {
    "required": {
      "text": [
        "STRING",
        {
          "forceInput": true
        }
      ],
      "substring": [
        "STRING",
        {
          "default": "",
          "multiline": false
        }
      ],
      "pattern": [
        "STRING",
        {
          "default": "",
          "multiline": false
        }
      ]
    }
  },
  "output": [
    "BOOLEAN"
  ],
  "output_is_list": [
    false
  ],
  "output_name": [
    "found"
  ],
  "name": "Text Find",
  "display_name": "Text Find",
  "description": "",
  "python_module": "custom_nodes.was-node-suite-comfyui",
  "category": "WAS Suite/Text/Search",
  "output_node": false
}
```