### PR TITLE
Fix WAS_Text_Random_Line `IS_CHANGED` method

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10290,10 +10290,6 @@ class WAS_Text_Random_Line:
         choice = random.choice(lines)
         return (choice, )
 
-    @classmethod
-    def IS_CHANGED(cls, **kwargs):
-        return float("NaN")
-
 
 # Text Concatenate
 


### PR DESCRIPTION
Custom `IS_CHANGED` is note needed in `WAS_Text_Random_Line`. 

- When `control_after_generate` is "fixed" the node should not run again.
- If not, than seed is changed anyway and the node will run again.