### PR TITLE
fix opencv-python handling to avoid conflict

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -14485,36 +14485,28 @@ if os.path.exists(BKAdvCLIP_dir):
         cstr('`CLIPTextEncode (BlenderNeko Advanced + NSP)` node enabled under `WAS Suite/Conditioning` menu.').msg.print()
 
 # opencv-python-headless handling
-if 'opencv-python' in packages() or 'opencv-python-headless' in packages():
-    try:
-        import cv2
-        build_info = ' '.join(cv2.getBuildInformation().split())
-        if "FFMPEG: YES" in build_info:
-            if was_config.__contains__('show_startup_junk'):
-                if was_config['show_startup_junk']:
-                    cstr("OpenCV Python FFMPEG support is enabled").msg.print()
-            if was_config.__contains__('ffmpeg_bin_path'):
-                if was_config['ffmpeg_bin_path'] == "/path/to/ffmpeg":
-                    cstr(f"`ffmpeg_bin_path` is not set in `{WAS_CONFIG_FILE}` config file. Will attempt to use system ffmpeg binaries if available.").warning.print()
-                else:
-                    if was_config.__contains__('show_startup_junk'):
-                        if was_config['show_startup_junk']:
-                            cstr(f"`ffmpeg_bin_path` is set to: {was_config['ffmpeg_bin_path']}").msg.print()
-        else:
-            cstr(f"OpenCV Python FFMPEG support is not enabled\033[0m. OpenCV Python FFMPEG support, and FFMPEG binaries is required for video writing.").warning.print()
-    except ImportError:
-        cstr("OpenCV Python module cannot be found. Attempting install...").warning.print()
-        install_package(
-            package='opencv-python-headless[ffmpeg]',
-            uninstall_first=['opencv-python', 'opencv-python-headless[ffmpeg]']
-        )
-        try:
-            import cv2
-            cstr("OpenCV Python installed.").msg.print()
-        except ImportError:
-            cstr("OpenCV Python module still cannot be imported. There is a system conflict.").error.print()
-else:
-    install_package('opencv-python-headless[ffmpeg]')
+try:
+    import cv2
+    build_info = ' '.join(cv2.getBuildInformation().split())
+    if "FFMPEG: YES" in build_info:
+        if was_config.__contains__('show_startup_junk'):
+            if was_config['show_startup_junk']:
+                cstr("OpenCV Python FFMPEG support is enabled").msg.print()
+        if was_config.__contains__('ffmpeg_bin_path'):
+            if was_config['ffmpeg_bin_path'] == "/path/to/ffmpeg":
+                cstr(f"`ffmpeg_bin_path` is not set in `{WAS_CONFIG_FILE}` config file. Will attempt to use system ffmpeg binaries if available.").warning.print()
+            else:
+                if was_config.__contains__('show_startup_junk'):
+                    if was_config['show_startup_junk']:
+                        cstr(f"`ffmpeg_bin_path` is set to: {was_config['ffmpeg_bin_path']}").msg.print()
+    else:
+        cstr(f"OpenCV Python FFMPEG support is not enabled\033[0m. OpenCV Python FFMPEG support, and FFMPEG binaries is required for video writing.").warning.print()
+except ImportError:
+    cstr("OpenCV Python module cannot be found. Attempting install...").warning.print()
+    install_package(
+        package='opencv-python-headless[ffmpeg]',
+        uninstall_first=['opencv-python', 'opencv-python-headless[ffmpeg]']
+    )
     try:
         import cv2
         cstr("OpenCV Python installed.").msg.print()


### PR DESCRIPTION
There are four opencv python packages:

- opencv-python
- opencv-contrib-python
- opencv-python-headless
- opencv-contrib-python-headless

Only one of them should be installed otherwise there would have conflict.

The code line

https://github.com/WASasquatch/was-node-suite-comfyui/blob/ee2e31a1e5fd85ad6f5c36831ffda6fea8f249c7/WAS_Node_Suite.py#L14488

only consider opencv-python and opencv-python-headless and the other two are not considered. The above line is also not neccessary because if opencv package was not installed, an ImportError exception would be thrown.

This PR tries to fix this problem.