### PR TITLE
Expand environment variables in file paths for dynamic loading from file

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10980,6 +10980,8 @@ class WAS_Text_Load_From_File:
     CATEGORY = "WAS Suite/IO"
 
     def load_file(self, file_path='', dictionary_name='[filename]]'):
+        # Expand environment variables in the file path
+        file_path = os.path.expandvars(file_path)
 
         filename = ( os.path.basename(file_path).split('.', 1)[0]
             if '.' in os.path.basename(file_path) else os.path.basename(file_path) )

--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -11045,6 +11045,9 @@ class WAS_Text_Load_Line_From_File:
 
     def load_file(self, file_path='', dictionary_name='[filename]', label='TextBatch',
                   mode='automatic', index=0, multiline_text=None):
+        # Expand environment variables in the file path
+        file_path = os.path.expandvars(file_path)
+                      
         if multiline_text is not None:
             lines = multiline_text.strip().split('\n')
             if mode == 'index':


### PR DESCRIPTION
### Overview

This pull request introduces a feature to enhance file loading functionality across the WAS Node Suite by supporting environment variables in file paths. This change ensures that paths containing variables such as `%userprofile%` are correctly expanded and interpreted, allowing for more dynamic and flexible file loading.

### Changes Made

1. **WAS_Text_Load_Line_From_File**:
   - Updated the `load_file` method to expand environment variables in the `file_path` using `os.path.expandvars()`.
   - This change resolves an issue where paths with environment variables could not be found, resulting in errors.

2. **WAS_Text_Load_From_File**:
   - Applied the same update to the `load_file` method in this class to ensure consistent behavior.
   - Environment variables in the `file_path` are now properly expanded before the path is used.

### Impact

- **Improved Flexibility**: Users can now specify file paths that include environment variables, allowing the code to adapt to different user environments seamlessly.
- **Consistency**: Both `WAS_Text_Load_Line_From_File` and `WAS_Text_Load_From_File` now handle file paths in the same manner, ensuring consistent behavior across the suite.

### Additional Notes

- I wanted to use `%userprofile%\Documents\` as a file path. It was not supported, so I added this feature. 