### PR TITLE
Remove restrictions on the opencv version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ joblib
 matplotlib
 numba
 numpy
-opencv-python-headless[ffmpeg]<=4.7.0.72
+opencv-python-headless[ffmpeg]
 pilgram
 git+https://github.com/WASasquatch/ffmpy.git
 rembg


### PR DESCRIPTION
According to [blame of `requirements.txt`](https://github.com/WASasquatch/was-node-suite-comfyui/commit/98b4943f9661d2407404d8a9ee520a3a32a76e7f) the `<=4.7.0.72` restriction was added more than a year ago.

Since then, numpy 2 became a thing, and opencv was changed to use numpy 2. Lots of other Comfy plugins use opencv without version restrictions, and pip just installs the latest >= 4.10.

But when installing was-node-suite, because of the `<=4.7.0.72` restriction, it downgrades opencv-python-headless to version 4.7.0.72, which uses numpy 1. Pip gladly removes opencv-python-headless 4.10+ and installs the older version, but it doesn't downgrade numpy. Then in the runtime, when importing `cv`, the import fails with:

> A module that was compiled using NumPy 1.x cannot be run in
> NumPy 2.0.2 as it may crash. To support both 1.x and 2.x
> versions of NumPy, modules must be compiled with NumPy 2.0.
> Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
> 
> If you are a user of the module, the easiest solution will be to
> downgrade to 'numpy<2' or try to upgrade the affected module.
> We expect that some modules will need time to support NumPy 2.

I couldn't figure out why `<=4.7.0.72` restriction was needed > year ago. Things seem to work fine without it.
