### PR TITLE
Add contrib opencv packages to the opencv check.

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -14505,7 +14505,9 @@ if os.path.exists(BKAdvCLIP_dir):
         cstr('`CLIPTextEncode (BlenderNeko Advanced + NSP)` node enabled under `WAS Suite/Conditioning` menu.').msg.print()
 
 # opencv-python-headless handling
-if 'opencv-python' in packages() or 'opencv-python-headless' in packages():
+installed_packages = packages()
+opencv_candidates = ['opencv-python', 'opencv-python-headless', 'opencv-contrib-python', 'opencv-contrib-python-headless']
+if any(package in installed_packages for package in opencv_candidates):
     try:
         import cv2
         build_info = ' '.join(cv2.getBuildInformation().split())


### PR DESCRIPTION
This commit adds contrib versions of opencv to the list of candidate opencv packages, in addition to opencv-python and opencv-python-headless.