### PR TITLE
Fix Text Find node to return tuple (Issue #481) to avoid 'object of t…

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10380,9 +10380,9 @@ class WAS_Find:
 
     def execute(self, text, substring, pattern):
         if substring:
-            return substring in text
+            return (substring in text, )
 
-        return bool(re.search(pattern, text))
+        return (bool(re.search(pattern, text)), )
 
 
 


### PR DESCRIPTION
This PR fixes the issue #481.
The `execute` method now returns a tuple, matching the expected return type and preventing the error.