### PR TITLE
Change node name for Comfy Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pr-was-node-suite-comfyui-47064894"
+name = "was-node-suite-comfyui"
 description = ""
 version = "1.0.2"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Hey! 

The PR bot that created the node name had some issue. Currently users will install this node as `custom_nodes/pr-was-node-suite-comfyui-47064894`. 

Let's fix that. Once this PR merges I will rename the existing node versions to this new node name as well. 