### PR TITLE
Update WAS_Node_Suite.py

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -7352,7 +7352,7 @@ class WAS_Image_Save:
         if not os.path.isabs(output_path):
             output_path = os.path.join(self.output_dir, output_path)
         base_output = os.path.basename(output_path)
-        if output_path.endswith("ComfyUI/output") or output_path.endswith("ComfyUI\output"):
+        if output_path.endswith("ComfyUI/output") or output_path.endswith(r"ComfyUI\output"):
             base_output = ""
 
         # Check output destination


### PR DESCRIPTION
line 7355 was using \o == escape sequence. Changed to be a literal