### PR TITLE
Fix text-find-and-replace node to support text-dictionary-new node

### DIFF
--- a/WAS_Node_Suite.py
+++ b/WAS_Node_Suite.py
@@ -10721,7 +10721,8 @@ class WAS_Search_and_Replace_Dictionary:
             tkey = f'{replacement_key}{term}{replacement_key}'
             tcount = new_text.count(tkey)
             for _ in range(tcount):
-                new_text = new_text.replace(tkey, random.choice(dictionary[term]), 1)
+                _replace_value = random.choice(dictionary[term]) if isinstance(dictionary[term], list) else dictionary[term]
+                new_text = new_text.replace(tkey, _replace_value, 1)
                 if seed > 0 or seed < 0:
                     seed = seed + 1
                     random.seed(seed)


### PR DESCRIPTION
## Description
This PR resolves an issue with the text find and replace by dictionary node where an error occurs when using a dictionary generated by the text-dictionary-new node. The issue was caused by a type mismatch: the find-and-replace node expects Dict[str, List[str]], while the dictionary node generates Dict[str, str].

## Workflow
![NewDictionaryReplaceProblem_issue](https://github.com/user-attachments/assets/471ff88e-e034-4582-a7d1-962df48ed808)
![NewDictionaryReplaceProblem_test](https://github.com/user-attachments/assets/1577bfe1-08a9-4933-9061-5637c5dbf8e3)

## Changes
Updated the replacement logic to check if the dictionary value is a list. If it is not a list, the value is used directly.

## Note:
English is not my first language, and I used an AI assistant (Copilot) to help compose this Pull Request. I appreciate any suggestions to improve clarity or expression.
